### PR TITLE
Fix crash when MM/YY has invalid chars

### DIFF
--- a/app/src/main/java/com/konifar/cardinputhelperexample/MainActivity.kt
+++ b/app/src/main/java/com/konifar/cardinputhelperexample/MainActivity.kt
@@ -162,6 +162,7 @@ class MainActivity : AppCompatActivity() {
             CardMonthYearError.YEAR_OVER_20_YEARS_LATER -> R.string.month_year_error_year_invalid
             CardMonthYearError.YEAR_REQUIRED -> R.string.month_year_error_year_required
             CardMonthYearError.MONTH_INVALID -> R.string.month_year_error_month_invalid
+            CardMonthYearError.YEAR_INVALID -> R.string.month_year_error_year_invalid
             CardMonthYearError.MONTH_REQUIRED -> R.string.month_year_error_month_required
             CardMonthYearError.EMPTY -> R.string.month_year_error_empty
             else -> 0

--- a/library/src/main/java/io/konifar/cardinputhelper/validator/CardMonthYearValidator.kt
+++ b/library/src/main/java/io/konifar/cardinputhelper/validator/CardMonthYearValidator.kt
@@ -39,15 +39,18 @@ object CardMonthYearValidator {
 
     private fun checkMonthYear(month: String, year: String): CardMonthYearError? {
         if (month.isEmpty()) return CardMonthYearError.MONTH_REQUIRED
-        if (month.toInt() > 12 || month.toInt() <= 0) return CardMonthYearError.MONTH_INVALID
+        val monthInt = month.toIntOrNull()
+        if (monthInt == null || monthInt > 12 || monthInt <= 0) return CardMonthYearError.MONTH_INVALID
 
         if (year.isEmpty()) return CardMonthYearError.YEAR_REQUIRED
+
+        val yearInt = year.toIntOrNull() ?: return CardMonthYearError.YEAR_INVALID
 
         val currentYear = Calendar.getInstance().get(Calendar.YEAR) % 100
         val currentMonth = Calendar.getInstance().get(Calendar.MONTH) + 1
 
-        if (year.toInt() > currentYear + 20) return CardMonthYearError.YEAR_OVER_20_YEARS_LATER
-        if (year.toInt() < currentYear || (year.toInt() == currentYear && month.toInt() < currentMonth)) return CardMonthYearError.EXPIRED
+        if (yearInt > currentYear + 20) return CardMonthYearError.YEAR_OVER_20_YEARS_LATER
+        if (yearInt < currentYear || (yearInt == currentYear && monthInt < currentMonth)) return CardMonthYearError.EXPIRED
 
         return null
     }

--- a/library/src/main/java/io/konifar/cardinputhelper/validator/errors/CardMonthYearError.kt
+++ b/library/src/main/java/io/konifar/cardinputhelper/validator/errors/CardMonthYearError.kt
@@ -6,6 +6,7 @@ enum class CardMonthYearError {
     MONTH_INVALID,
     YEAR_REQUIRED,
     YEAR_OVER_20_YEARS_LATER,
+    YEAR_INVALID,
     EXPIRED,
     NONE,
 }

--- a/library/src/test/java/io/konifar/cardinputhelper/validator/CardMonthYearValidatorTest.kt
+++ b/library/src/test/java/io/konifar/cardinputhelper/validator/CardMonthYearValidatorTest.kt
@@ -28,7 +28,12 @@ class CardMonthYearValidatorTest {
                     arrayOf("13/1", CardMonthYearError.MONTH_INVALID),
                     arrayOf("1/", CardMonthYearError.YEAR_REQUIRED),
                     arrayOf("12/", CardMonthYearError.YEAR_REQUIRED),
-                    arrayOf("12/36", CardMonthYearError.NONE)
+                    arrayOf("12/36", CardMonthYearError.NONE),
+                    arrayOf(" /36", CardMonthYearError.MONTH_INVALID),
+                    arrayOf(";/36", CardMonthYearError.MONTH_INVALID),
+                    arrayOf("12/ ", CardMonthYearError.YEAR_INVALID),
+                    arrayOf("12/;", CardMonthYearError.YEAR_INVALID),
+                    arrayOf(" / ", CardMonthYearError.MONTH_INVALID)
                 )
             }
         }
@@ -58,7 +63,14 @@ class CardMonthYearValidatorTest {
                     arrayOf("13/35", CardMonthYearError.MONTH_INVALID),
                     arrayOf("1/", CardMonthYearError.NONE),
                     arrayOf("12/", CardMonthYearError.NONE),
-                    arrayOf("12/36", CardMonthYearError.NONE)
+                    arrayOf("12/36", CardMonthYearError.NONE),
+                    arrayOf(" /36", CardMonthYearError.MONTH_INVALID),
+                    arrayOf(";/36", CardMonthYearError.MONTH_INVALID),
+                    arrayOf("12/ ", CardMonthYearError.NONE),
+                    arrayOf("12/;", CardMonthYearError.NONE),
+                    arrayOf(" / ", CardMonthYearError.NONE),
+                    arrayOf("12/  ", CardMonthYearError.YEAR_INVALID),
+                    arrayOf("12/;;", CardMonthYearError.YEAR_INVALID)
                 )
             }
         }


### PR DESCRIPTION
## Overview

- `CardMonthYearValidator.validate~()` occurs the crash when MM/YY has invalid chars like `12/;`, `12/ `.
- I fixed it to return proper error when it contains the invalid chars.