### PR TITLE
CardMonthYearText: ATOK で 10月・11月・12月を入力しようとするとカーソルポジションが不正となる

### DIFF
--- a/buildSrc/src/main/java/dependencies/Depends.kt
+++ b/buildSrc/src/main/java/dependencies/Depends.kt
@@ -4,7 +4,7 @@ package dependencies
 object Depends {
 
     object GradlePlugin {
-        const val android = "com.android.tools.build:gradle:4.0.0-alpha09"
+        const val android = "com.android.tools.build:gradle:4.1.0"
         const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Kotlin.version}"
         const val kotlinSerialization = "org.jetbrains.kotlin:kotlin-serialization:${Kotlin.version}"
         const val mavenGradlePlugin = "com.github.dcendents:android-maven-gradle-plugin:2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/library/src/main/java/io/konifar/cardinputhelper/CardMonthYearTextWatcher.kt
+++ b/library/src/main/java/io/konifar/cardinputhelper/CardMonthYearTextWatcher.kt
@@ -42,14 +42,16 @@ open class CardMonthYearTextWatcher(
                 CardMonthYearFormatter.formatForInsert(s)
             }
 
-            s.replace(0, s.length, formattedText)
-            val error = CardMonthYearValidator.validateOnTextChanged(formattedText)
-            onCardMonthYearErrorChanged(error)
+            if (formattedText != beforeText) {
+                s.replace(0, s.length, formattedText)
+                val error = CardMonthYearValidator.validateOnTextChanged(formattedText)
+                onCardMonthYearErrorChanged(error)
 
-            val cursorPos = CardMonthYearFormatter.calculateCursorPos(formattedText, beforeText, oldBeforeText)
-            Selection.setSelection(s, cursorPos)
+                val cursorPos = CardMonthYearFormatter.calculateCursorPos(formattedText, beforeText, oldBeforeText)
+                Selection.setSelection(s, cursorPos)
 
-            checkEditCompleted(formattedText)
+                checkEditCompleted(formattedText)
+            }
 
             isChangingText = false
         }


### PR DESCRIPTION
Android 8.0 + ATOK 環境で以下の問題が発生することを確認しています。

CardMonthYearText に対して「1025」と入力したら「1/02」と入力される。

動作としては、「1」を入力したときに「1{corsor}/」となるのが正しいが、「1/{corsor}」となってしまう点が問題です。

ATOK 以外のキーボードでは発生していません。
ATOK 以外のキーボードでは「1」を入力すると afterTextChanged() が1回のみ呼び出されていますが、
ATOK では「1」を入力すると afterTextChanged() が2回呼び出されています。

修正の方針としては、 ( beforeTextChanged() + afterTextChanged() ) の冪等性を担保するのが本来の形と思います。
afterTextChanged() により、文字列のフォーマットが必要なければ入力値もカーソルポジションも変更しないように修正しました。

また、手元でビルドするために必要であったため、 Gradle 6.7, Android Gradle Plugin 4.1.0 へのアップデートコミットも含んでいます。
